### PR TITLE
Add elementary school split stats

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -268,6 +268,20 @@
                 </div>
 
                 <hr/>
+                <div style="text-align: left">
+                    <ol>
+                        <li>Elementary Splits per high school represent the total
+                            number of elementary schools that are split and feeding
+                            to the high school. Total elementary splits represent
+                            the total number of splits in the district. An
+                            elementary school split three ways will contribute 1
+                            split to each high school and 3 splits to the total. An
+                            elementary school feeding only one high school will not
+                            contribute to either score.</li>
+                    </ol>
+                </div>
+
+                <hr/>
                 This is a community generated map and is not endorsed in any way
                 by the Beaverton School District.
             </div> <!-- page -->


### PR DESCRIPTION
Add elementary school split tracking as a means to quantify neighborhood unity.
Add a footnotes section describing the meaning of the values. This can be used
to describe other metrics as well.

Elementary Splits per high school represent the total number of elementary
schools that are split and feeding to the high school. Total elementary splits
represent the total number of splits in the district. An elementary school
split three ways will contribute 1 split to each high school and 3 splits to
the total. An elementary school feeding only one high school will not
contribute to either score.

Signed-off-by: Darren Hart dvhart@infradead.org
